### PR TITLE
Fixed to work with agile plugin

### DIFF
--- a/assets/stylesheets/sidebar_hide.css
+++ b/assets/stylesheets/sidebar_hide.css
@@ -29,7 +29,7 @@
 }
 
 #sidebar {
-  z-index:10000;
+  z-index:12;
 }
 
 #sidebar.sidebar_hidden {

--- a/assets/stylesheets/sidebar_hide.css
+++ b/assets/stylesheets/sidebar_hide.css
@@ -28,6 +28,10 @@
   position: relative;
 }
 
+#sidebar {
+  z-index:10000;
+}
+
 #sidebar.sidebar_hidden {
   display: none;
 }


### PR DESCRIPTION
When dragging user name from sidebar in agile plugin, due to using position:relative label with name was going under `#content` block