### PR TITLE
Fix z-index css property on main #content element

### DIFF
--- a/assets/stylesheets/sidebar_hide.css
+++ b/assets/stylesheets/sidebar_hide.css
@@ -26,6 +26,7 @@
 
 #content {
   position: relative;
+  z-index:0;
 }
 
 #sidebar {


### PR DESCRIPTION
This PR address these issues: #44 & #43 and complete this PR #45 

Relative elements have a different stack. When changing the `position` attribute of #content, we should also set the z-index value.